### PR TITLE
node: Remove --without-snapshot build option

### DIFF
--- a/alpine/aarch64/build.sh
+++ b/alpine/aarch64/build.sh
@@ -18,7 +18,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib --without-snapshot \
+	&& ./configure --prefix=/ --shared-zlib \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/amd64/build.sh
+++ b/alpine/amd64/build.sh
@@ -18,7 +18,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib --without-snapshot \
+	&& ./configure --prefix=/ --shared-zlib \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/armhf/build.sh
+++ b/alpine/armhf/build.sh
@@ -18,7 +18,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib --without-snapshot \
+	&& ./configure --prefix=/ --shared-zlib \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/i386/build.sh
+++ b/alpine/i386/build.sh
@@ -18,7 +18,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib --without-snapshot \
+	&& ./configure --prefix=/ --shared-zlib \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/debian/aarch64/build.sh
+++ b/debian/aarch64/build.sh
@@ -16,7 +16,7 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
-BUILD_FLAGs='--without-snapshot'
+BUILD_FLAGs=''
 
 # compile node
 cd node \

--- a/debian/armel/build.sh
+++ b/debian/armel/build.sh
@@ -13,7 +13,7 @@ DEST_DIR=node-v$NODE_VERSION-linux-$ARCH_VERSION
 TAR_FILE=node-v$NODE_VERSION-linux-$ARCH_VERSION.tar.gz
 BUCKET_NAME=$BUCKET_NAME
 
-BUILD_FLAGs="--without-snapshot --prefix / --with-arm-float-abi=softfp --dest-cpu=$ARCH"
+BUILD_FLAGs="--prefix / --with-arm-float-abi=softfp --dest-cpu=$ARCH"
 # --with-arm-fpu flag is not available for node versions 0.12.x and 0.10.x
 if version_ge "$NODE_VERSION" "4"; then
 	BUILD_FLAGs+=' --with-arm-fpu=vfp'

--- a/debian/armv6hf/build.sh
+++ b/debian/armv6hf/build.sh
@@ -12,7 +12,7 @@ ARCH_VERSION=armv6hf
 TAR_FILE=node-v$NODE_VERSION-linux-$ARCH_VERSION.tar.gz
 BUCKET_NAME=$BUCKET_NAME
 
-BUILD_FLAGs='--without-snapshot'
+BUILD_FLAGs=''
 
 if version_ge "$NODE_VERSION" "6"; then
 # ref https://github.com/nodejs/node/issues/7173

--- a/debian/armv7hf/build.sh
+++ b/debian/armv7hf/build.sh
@@ -15,7 +15,7 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
-BUILD_FLAGs='--without-snapshot'
+BUILD_FLAGs=''
 
 # compile node
 cd node \

--- a/debian/i386/build.sh
+++ b/debian/i386/build.sh
@@ -16,7 +16,7 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
-BUILD_FLAGs="--prefix / --dest-cpu=ia32 --without-snapshot"
+BUILD_FLAGs="--prefix / --dest-cpu=ia32"
 
 # compile node
 cd node \


### PR DESCRIPTION
Fix #63, this will set v8_use_snapshot to true which will improve node performance. All security flaws related to this build option were patched so it is safe to remove it.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>