### PR TITLE
Add more build options to the build script

### DIFF
--- a/alpine/aarch64/build.sh
+++ b/alpine/aarch64/build.sh
@@ -2,6 +2,8 @@
 set -e
 set -o pipefail
 
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-aarch64
@@ -15,10 +17,17 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
+BUILD_FLAGS='--prefix=/ --shared-zlib'
+
+# Enable lto from node v11 onwards
+if (version_ge $NODE_VERSION "11"); then
+	BUILD_FLAGS+=' --enable-lto'
+fi
+
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib \
+	&& ./configure "$BUILD_FLAGS" \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/aarch64/build.sh
+++ b/alpine/aarch64/build.sh
@@ -7,9 +7,9 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-aarch64
-TAR_FILE=node-v$NODE_VERSION-linux-$ARCH.tar.gz
 BUCKET_NAME=$BUCKET_NAME
 BINARYNAME=node-v$NODE_VERSION-linux-$ARCH
+TAR_FILE=$BINARYNAME.tar.gz
 
 commit=($(echo "$(grep " v$NODE_VERSION" /commit-table)" | tr " " "\n"))
 if [ -z $commit ]; then
@@ -22,6 +22,13 @@ BUILD_FLAGS='--prefix=/ --shared-zlib'
 # Enable lto from node v11 onwards
 if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+=' --enable-lto'
+fi
+
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	BINARYNAME=node-no-intl-v$NODE_VERSION-linux-$ARCH
+	TAR_FILE=$BINARYNAME.tar.gz
 fi
 
 # compile node

--- a/alpine/aarch64/build.sh
+++ b/alpine/aarch64/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 set -o pipefail
 
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
@@ -34,7 +34,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure "$BUILD_FLAGS" \
+	&& ./configure $BUILD_FLAGS \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/amd64/build.sh
+++ b/alpine/amd64/build.sh
@@ -7,9 +7,9 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-amd64
-TAR_FILE=node-v$NODE_VERSION-linux-$ARCH.tar.gz
 BUCKET_NAME=$BUCKET_NAME
 BINARYNAME=node-v$NODE_VERSION-linux-$ARCH
+TAR_FILE=$BINARYNAME.tar.gz
 
 commit=($(echo "$(grep " v$NODE_VERSION" /commit-table)" | tr " " "\n"))
 if [ -z $commit ]; then
@@ -22,6 +22,13 @@ BUILD_FLAGS='--prefix=/ --shared-zlib'
 # Enable lto from node v11 onwards
 if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+=' --enable-lto'
+fi
+
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	BINARYNAME=node-no-intl-v$NODE_VERSION-linux-$ARCH
+	TAR_FILE=$BINARYNAME.tar.gz
 fi
 
 # compile node

--- a/alpine/amd64/build.sh
+++ b/alpine/amd64/build.sh
@@ -2,6 +2,8 @@
 set -e
 set -o pipefail
 
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-amd64
@@ -15,10 +17,17 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
+BUILD_FLAGS='--prefix=/ --shared-zlib'
+
+# Enable lto from node v11 onwards
+if (version_ge $NODE_VERSION "11"); then
+	BUILD_FLAGS+=' --enable-lto'
+fi
+
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib \
+	&& ./configure "$BUILD_FLAGS" \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/amd64/build.sh
+++ b/alpine/amd64/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 set -o pipefail
 
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
@@ -34,7 +34,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure "$BUILD_FLAGS" \
+	&& ./configure $BUILD_FLAGS \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/armv6hf/build.sh
+++ b/alpine/armv6hf/build.sh
@@ -2,6 +2,8 @@
 set -e
 set -o pipefail
 
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-armv6hf
@@ -15,10 +17,17 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
+BUILD_FLAGS='--prefix=/ --shared-zlib'
+
+# Enable lto from node v11 onwards
+if (version_ge $NODE_VERSION "11"); then
+	BUILD_FLAGS+=' --enable-lto'
+fi
+
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib \
+	&& ./configure "$BUILD_FLAGS" \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/armv6hf/build.sh
+++ b/alpine/armv6hf/build.sh
@@ -6,7 +6,7 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 
 # set env var
 NODE_VERSION=$1
-ARCH=alpine-armv6hf
+ARCH=alpine-rpi
 BUCKET_NAME=$BUCKET_NAME
 BINARYNAME=node-v$NODE_VERSION-linux-$ARCH
 TAR_FILE=$BINARYNAME.tar.gz

--- a/alpine/armv6hf/build.sh
+++ b/alpine/armv6hf/build.sh
@@ -7,9 +7,9 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-armv6hf
-TAR_FILE=node-v$NODE_VERSION-linux-$ARCH.tar.gz
 BUCKET_NAME=$BUCKET_NAME
 BINARYNAME=node-v$NODE_VERSION-linux-$ARCH
+TAR_FILE=$BINARYNAME.tar.gz
 
 commit=($(echo "$(grep " v$NODE_VERSION" /commit-table)" | tr " " "\n"))
 if [ -z $commit ]; then
@@ -22,6 +22,13 @@ BUILD_FLAGS='--prefix=/ --shared-zlib'
 # Enable lto from node v11 onwards
 if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+=' --enable-lto'
+fi
+
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	BINARYNAME=node-no-intl-v$NODE_VERSION-linux-$ARCH
+	TAR_FILE=$BINARYNAME.tar.gz
 fi
 
 # compile node

--- a/alpine/armv6hf/build.sh
+++ b/alpine/armv6hf/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 set -o pipefail
 
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
@@ -34,7 +34,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure "$BUILD_FLAGS" \
+	&& ./configure $BUILD_FLAGS \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/armv7hf/build.sh
+++ b/alpine/armv7hf/build.sh
@@ -2,6 +2,8 @@
 set -e
 set -o pipefail
 
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-armv7hf
@@ -15,10 +17,17 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
+BUILD_FLAGS='--prefix=/ --shared-zlib'
+
+# Enable lto from node v11 onwards
+if (version_ge $NODE_VERSION "11"); then
+	BUILD_FLAGS+=' --enable-lto'
+fi
+
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib \
+	&& ./configure "$BUILD_FLAGS" \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/armv7hf/build.sh
+++ b/alpine/armv7hf/build.sh
@@ -7,9 +7,9 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-armv7hf
-TAR_FILE=node-v$NODE_VERSION-linux-$ARCH.tar.gz
 BUCKET_NAME=$BUCKET_NAME
 BINARYNAME=node-v$NODE_VERSION-linux-$ARCH
+TAR_FILE=$BINARYNAME.tar.gz
 
 commit=($(echo "$(grep " v$NODE_VERSION" /commit-table)" | tr " " "\n"))
 if [ -z $commit ]; then
@@ -22,6 +22,13 @@ BUILD_FLAGS='--prefix=/ --shared-zlib'
 # Enable lto from node v11 onwards
 if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+=' --enable-lto'
+fi
+
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	BINARYNAME=node-no-intl-v$NODE_VERSION-linux-$ARCH
+	TAR_FILE=$BINARYNAME.tar.gz
 fi
 
 # compile node

--- a/alpine/i386/build.sh
+++ b/alpine/i386/build.sh
@@ -7,9 +7,9 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-i386
-TAR_FILE=node-v$NODE_VERSION-linux-$ARCH.tar.gz
 BUCKET_NAME=$BUCKET_NAME
 BINARYNAME=node-v$NODE_VERSION-linux-$ARCH
+TAR_FILE=$BINARYNAME.tar.gz
 
 commit=($(echo "$(grep " v$NODE_VERSION" /commit-table)" | tr " " "\n"))
 if [ -z $commit ]; then
@@ -22,6 +22,13 @@ BUILD_FLAGS='--prefix=/ --shared-zlib'
 # Enable lto from node v11 onwards
 if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+=' --enable-lto'
+fi
+
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	BINARYNAME=node-no-intl-v$NODE_VERSION-linux-$ARCH
+	TAR_FILE=$BINARYNAME.tar.gz
 fi
 
 # compile node

--- a/alpine/i386/build.sh
+++ b/alpine/i386/build.sh
@@ -2,6 +2,8 @@
 set -e
 set -o pipefail
 
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
 # set env var
 NODE_VERSION=$1
 ARCH=alpine-i386
@@ -15,10 +17,17 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
+BUILD_FLAGS='--prefix=/ --shared-zlib'
+
+# Enable lto from node v11 onwards
+if (version_ge $NODE_VERSION "11"); then
+	BUILD_FLAGS+=' --enable-lto'
+fi
+
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure --prefix=/ --shared-zlib \
+	&& ./configure "$BUILD_FLAGS" \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/alpine/i386/build.sh
+++ b/alpine/i386/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 set -o pipefail
 
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
@@ -34,7 +34,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure "$BUILD_FLAGS" \
+	&& ./configure $BUILD_FLAGS \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -18,7 +18,8 @@ do
 		fi
 		docker build --no-cache=true -t node-$DISTRO-$ARCH-builder .		
 	fi
-	docker run --rm -e ACCESS_KEY=$ACCESS_KEY \
+	docker run --rm -e NONE_INTL=$NONE_INTL \
+					-e ACCESS_KEY=$ACCESS_KEY \
 					-e SECRET_KEY=$SECRET_KEY \
 					-e BUCKET_NAME=$BUCKET_NAME node-$DISTRO-$ARCH-builder bash build.sh $NODE_VERSION
 done

--- a/debian/aarch64/build.sh
+++ b/debian/aarch64/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 set -o pipefail
 
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
@@ -34,7 +34,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure DESTCPU=$ARCH "$BUILD_FLAGS" \
+	&& ./configure DESTCPU=$ARCH $BUILD_FLAGS \
 	&& make install -j$(nproc) DESTDIR=$DEST_DIR V=1 PORTABLE=1 \
 	&& tar -cvzf $TAR_FILE $DEST_DIR \
 	&& curl -SLO "http://resin-packages.s3.amazonaws.com/SHASUMS256.txt" \

--- a/debian/aarch64/build.sh
+++ b/debian/aarch64/build.sh
@@ -25,6 +25,12 @@ if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+=' --enable-lto'
 fi
 
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	TAR_FILE=node-no-intl-v$NODE_VERSION-linux-$ARCH_VERSION.tar.gz
+fi
+
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \

--- a/debian/amd64/Dockerfile.tpl
+++ b/debian/amd64/Dockerfile.tpl
@@ -1,0 +1,13 @@
+FROM balenalib/amd64-debian:#{SUITE}
+
+RUN apt-get -q update \
+		&& apt-get install -y git python python-dev python-pip python-setuptools build-essential wget ca-certificates libssl-dev curl --no-install-recommends \
+		&& apt-get clean \
+		&& rm -rf /var/lib/apt/lists/*
+
+# Install AWS CLI
+RUN pip install awscli
+
+RUN git clone https://github.com/nodejs/node.git
+
+COPY . /

--- a/debian/armv6hf/build.sh
+++ b/debian/armv6hf/build.sh
@@ -8,7 +8,7 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 NODE_VERSION=$1
 ARCH_VERSION=armv6hf
 BINARYNAME=node-v$NODE_VERSION-linux-$ARCH_VERSION
-TAR_FILE=node-v$NODE_VERSION-linux-$ARCH_VERSION.tar.gz
+TAR_FILE=$BINARYNAME.tar.gz
 BUCKET_NAME=$BUCKET_NAME
 
 commit=($(echo "$(grep " v$NODE_VERSION" /commit-table)" | tr " " "\n"))
@@ -22,6 +22,13 @@ BUILD_FLAGS='--prefix=/'
 # Enable lto from node v11 onwards
 if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+=' --enable-lto'
+fi
+
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	BINARYNAME=node-no-intl-v$NODE_VERSION-linux-$ARCH_VERSION
+	TAR_FILE=$BINARYNAME.tar.gz
 fi
 
 # compile node

--- a/debian/armv6hf/build.sh
+++ b/debian/armv6hf/build.sh
@@ -6,7 +6,7 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 
 # set env var
 NODE_VERSION=$1
-ARCH_VERSION=armv6hf
+ARCH_VERSION=rpi
 BINARYNAME=node-v$NODE_VERSION-linux-$ARCH_VERSION
 TAR_FILE=$BINARYNAME.tar.gz
 BUCKET_NAME=$BUCKET_NAME

--- a/debian/armv6hf/build.sh
+++ b/debian/armv6hf/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 set -o pipefail
 
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
@@ -34,7 +34,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure "$BUILD_FLAGS" \
+	&& ./configure $BUILD_FLAGS \
    	&& make -j$(nproc) \
    	&& make install DESTDIR=$BINARYNAME PORTABLE=1 \
    	&& tar -cf $BINARYNAME.tar $BINARYNAME \

--- a/debian/armv7hf/build.sh
+++ b/debian/armv7hf/build.sh
@@ -2,6 +2,8 @@
 set -e
 set -o pipefail
 
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
 # set env var
 NODE_VERSION=$1
 ARCH=arm
@@ -15,12 +17,17 @@ if [ -z $commit ]; then
 	exit 1
 fi
 
-BUILD_FLAGs=''
+BUILD_FLAGS=''
+
+# Enable lto from node v11 onwards
+if (version_ge $NODE_VERSION "11"); then
+	BUILD_FLAGS+='--enable-lto'
+fi
 
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& make -j$(nproc) binary DESTCPU=$ARCH CONFIG_FLAGS=$BUILD_FLAGs \
+	&& make -j$(nproc) binary DESTCPU=$ARCH CONFIG_FLAGS=$BUILD_FLAGS \
 	&& mv node-v$NODE_VERSION-linux-$ARCH.tar.gz $TAR_FILE \
 	&& curl -SLO "http://resin-packages.s3.amazonaws.com/SHASUMS256.txt" \
 	&& sha256sum $TAR_FILE >> SHASUMS256.txt \

--- a/debian/armv7hf/build.sh
+++ b/debian/armv7hf/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 set -o pipefail
 
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }

--- a/debian/armv7hf/build.sh
+++ b/debian/armv7hf/build.sh
@@ -24,6 +24,12 @@ if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+='--enable-lto'
 fi
 
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	TAR_FILE=node-no-intl-v$NODE_VERSION-linux-$ARCH_VERSION.tar.gz
+fi
+
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \

--- a/debian/i386/build.sh
+++ b/debian/i386/build.sh
@@ -24,6 +24,12 @@ if (version_ge $NODE_VERSION "11"); then
 	BUILD_FLAGS+=' --enable-lto'
 fi
 
+# Add --with-intl=none flag and update binary name
+if [ ! -z "$NONE_INTL" ]; then
+	BUILD_FLAGS+=' --with-intl=none'
+	TAR_FILE=node-no-intl-v$NODE_VERSION-linux-$ARCH_VERSION.tar.gz
+fi
+
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \

--- a/debian/i386/build.sh
+++ b/debian/i386/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 set -o pipefail
 
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
@@ -33,7 +33,7 @@ fi
 # compile node
 cd node \
 	&& git checkout ${commit[0]} \
-	&& ./configure "$BUILD_FLAGS" \
+	&& ./configure $BUILD_FLAGS \
 	&& cat config.gypi \
 	&& make install -j$(nproc) DESTDIR=$DEST_DIR V=1 PORTABLE=1 \
 	&& cp LICENSE $DEST_DIR \


### PR DESCRIPTION
- Add --enable-lto build flag by default from node v11 and onwards.
- Add NONE_INTL env var to produce node binary without intl (for supervisor only)

